### PR TITLE
Build the release container on native arm64 runners

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,165 @@
+name: Container image
+
+# Builds and pushes the multi-arch CLI container to GHCR.
+#
+# Split out of release.yml so it can run on its own. The amd64 and arm64
+# layers each build on a NATIVE runner (no QEMU emulation), are pushed by
+# digest, then stitched into one manifest list. This avoids the emulated
+# arm64 Rust compile that timed the old single-job build out at 30 minutes.
+#
+# Triggers:
+#   - a v*.*.* tag push (the normal release path), and
+#   - workflow_dispatch with a tag input, so a release whose image failed
+#     to publish can be backfilled without moving the tag.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build the image from (e.g. v4.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # Resolve which tag we are building, for both trigger paths.
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve tag and version
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ref="${{ inputs.tag }}"
+          else
+            ref="${{ github.ref_name }}"
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
+
+  # Build each architecture on its own native runner and push by digest.
+  build:
+    needs: setup
+    timeout-minutes: 45
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.ref }}
+
+      - name: Derive lower-case image name and platform pair
+        run: |
+          echo "IMAGE_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_LC }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stitch the per-arch digests into a single tagged manifest list.
+  merge:
+    needs: [setup, build]
+    name: Merge manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Derive lower-case image name
+        run: echo "IMAGE_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          version="${{ needs.setup.outputs.version }}"
+          minor="${version%.*}"
+          image="${REGISTRY}/${IMAGE_LC}"
+          docker buildx imagetools create \
+            -t "${image}:${version}" \
+            -t "${image}:${minor}" \
+            -t "${image}:latest" \
+            $(printf "${image}@sha256:%s " *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect \
+            "${REGISTRY}/${IMAGE_LC}:${{ needs.setup.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   # ── Tauri desktop builds ──────────────────────────────────────────────────
@@ -111,53 +109,6 @@ jobs:
           releaseDraft: false
           prerelease: false
           args: --target universal-apple-darwin
-
-  # ── Docker multi-arch image ───────────────────────────────────────────────
-  docker:
-    timeout-minutes: 30
-    name: Docker (amd64 + arm64)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   # ── Checksums ─────────────────────────────────────────────────────────────
   checksums:


### PR DESCRIPTION
## What

Splits the multi-arch CLI container build out of `release.yml` into its own `docker-image.yml` workflow that builds each architecture on a **native** runner.

## Why

In the v4.1.0 release run the single Docker job built `linux/amd64` + `linux/arm64` together, with the arm64 half under QEMU emulation. The emulated Rust compile overran the 30 minute cap, the job was cancelled, and the container image never published (the desktop binaries, SBOM and checksums were unaffected).

A bigger timeout only papers over it: emulated arm64 Rust builds are slow and unpredictable. Since the repo is public, `ubuntu-24.04-arm` native runners are free.

## How

- Per-arch matrix (`ubuntu-latest` + `ubuntu-24.04-arm`), each pushing by digest, then a merge job stitches the manifest list. No QEMU; both arches build in parallel.
- Moved to its own workflow with a `workflow_dispatch` tag input so a release whose image failed to publish can be backfilled **without moving the tag**.
- Removed the now-unused `REGISTRY`/`IMAGE_NAME` env from `release.yml`.

Lower-case image name handled explicitly (`The-Malware-Files` -> `the-malware-files`) since GHCR requires it.